### PR TITLE
Update test cases for MVP

### DIFF
--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -1,8 +1,7 @@
 {
   "persons": [ {
     "name": "Hans Muster",
-    "phone": "9482424",
-    "email": "invalid@email!3e",
+    "phone": "91",
     "address": "4th street"
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -46,10 +46,8 @@ public class CommandTestUtil {
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
     public static final String PHONE_DESC_BOB = " " + PREFIX_PHONE + VALID_PHONE_BOB;
-    // public static final String EMAIL_DESC_AMY = " " + PREFIX_TAG + VALID_EMAIL_AMY;
-    // public static final String EMAIL_DESC_BOB = " " + PREFIX_TAG + VALID_EMAIL_BOB;
-    public static final String TAG_DESC_AMY = " " + PREFIX_EMAIL + VALID_TAG_AMY;
-    public static final String TAG_DESC_BOB = " " + PREFIX_EMAIL + VALID_TAG_BOB;
+    public static final String TAG_DESC_AMY = " " + PREFIX_TAG + VALID_TAG_AMY;
+    public static final String TAG_DESC_BOB = " " + PREFIX_TAG + VALID_TAG_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -43,10 +43,6 @@ public class EditPersonDescriptorTest {
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withPhone(VALID_PHONE_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
-        // different email -> returns false
-        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
-
         // different address -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withAddress(VALID_ADDRESS_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -171,7 +171,7 @@ public class EditCommandParserTest {
                 + PHONE_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_ADDRESS));
 
         // multiple invalid values
         userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC


### PR DESCRIPTION
Fixes #65 
This pull request mainly addresses issues related to test data and command utility constants, particularly focusing on correcting tag and email prefix usage and refining duplicate prefix error handling in tests. The changes help to improve test accuracy and maintain consistency in how prefixes are referenced and validated.

### Test Data and Validation Fixes

* Updated `invalidPersonAddressBook.json` to change the phone value for the test person, removing the invalid email field to better align with current validation rules.

### Command Utility Constants

* Fixed incorrect usage of tag and email prefixes in `CommandTestUtil.java` by restoring the correct tag prefix for tag descriptors and removing commented-out email descriptor constants.

### Test Logic and Error Handling

* Removed a redundant test case for different emails in `EditPersonDescriptorTest.java` to streamline equality checks.
* Updated duplicate prefix error handling in `EditCommandParserTest.java` to exclude the email prefix, ensuring error messages now only reference phone and address prefixes.