### PR TITLE
Fix delete command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -9,7 +9,9 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Caregiver;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Senior;
 
 /**
  * Deletes a person identified using it's displayed index from the address book.
@@ -41,6 +43,16 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        // If deleting a caregiver, clear references from seniors
+        if (personToDelete instanceof Caregiver c) {
+            model.getAddressBook().getPersonList().stream()
+                    .filter(p -> p instanceof Senior)
+                    .map(p -> (Senior) p)
+                    .filter(s -> s.getCaregiver() != null && s.getCaregiver().isSamePerson(c))
+                    .forEach(s -> s.setCaregiver(null));
+        }
+
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.format(personToDelete)));
     }


### PR DESCRIPTION
Fix #76 

Currently what happens is that delete command removes person from person list. the senior is removed from a list of seniors of a caregiver. however, the caregiver still remains an attribute of the senior. the changes of this pr sets the caregiver of the senior to null, and thus the caregiver of a senior will now display as unassigned once that caregiver is deleted.