### PR TITLE
Fix assign to pinned Caregivers

### DIFF
--- a/src/main/java/seedu/address/ui/CaregiverListPanel.java
+++ b/src/main/java/seedu/address/ui/CaregiverListPanel.java
@@ -58,7 +58,11 @@ public class CaregiverListPanel extends UiPart<Region> {
         caregiverList.addListener((ListChangeListener<Caregiver>) change -> caregiverListView.refresh());
         caregiverListView.setCellFactory(listView -> new CaregiverListViewCell(logic));
 
-        seniorList.addListener((ListChangeListener<Senior>) c -> caregiverListView.refresh());
+        seniorList.addListener((ListChangeListener<Senior>) c -> {
+            caregiverListView.refresh();
+            pinnedHeaderList.refresh();
+        });
+
         // header list: same cell factory so it looks identical
         pinnedHeaderList.setItems(pinnedHeaderItems);
         pinnedHeaderList.setCellFactory(listView -> new CaregiverListPanel.CaregiverListViewCell(logic));


### PR DESCRIPTION
Fix #113 

Updated the caregiver panel to refresh both the main list and pinned header whenever senior assignments change, ensuring pinned caregiver chips redraw immediately after assignment updates.