### PR TITLE
Add auto refresh list for commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCaregiverCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCaregiverCommand.java
@@ -60,6 +60,8 @@ public class AddCaregiverCommand extends Command {
         // Always allocate a fresh caregiver id
         final int caregiverId = model.allocateCaregiverId();
         model.addCaregiver(toAdd.withId(caregiverId));
+        model.updateFilteredCaregiverList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredSeniorList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.formatCaregiver(toAdd)));
     }

--- a/src/main/java/seedu/address/logic/commands/AddSeniorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSeniorCommand.java
@@ -82,6 +82,8 @@ public class AddSeniorCommand extends Command {
             toAddFinal = toAdd.withId(seniorId).withCaregiver(caregiver);
             model.addSenior(toAddFinal);
         }
+        model.updateFilteredCaregiverList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredSeniorList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.formatSenior(toAddFinal)));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -92,6 +93,9 @@ public class DeleteCommand extends Command {
                     .forEach(s -> s.setCaregiver(null));
             model.deleteCaregiver(caregiver);
         }
+
+        model.updateFilteredSeniorList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredCaregiverList(PREDICATE_SHOW_ALL_PERSONS);
 
         if (senior != null && caregiver == null) {
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, Messages.formatSenior(senior)));

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -114,6 +114,7 @@ public class EditCommand extends Command {
             }
 
             model.setSenior(seniorToEdit, editedSenior);
+            model.updateFilteredCaregiverList(Model.PREDICATE_SHOW_ALL_PERSONS);
             model.updateFilteredSeniorList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
             return new CommandResult(


### PR DESCRIPTION
Fixes #195 
Added refresh page to all commands(except help, exit filter and find) to standardize bahaviour of refreshing list after commands that makes changes to the list.